### PR TITLE
Alternate generated filename

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,7 @@ x64/
 *.vspscc
 *.vssscc
 .builds
+*.scc
 
 # Visual C++ cache files
 ipch/

--- a/TinyPG/CodeGenerators/BaseGenerator.cs
+++ b/TinyPG/CodeGenerators/BaseGenerator.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace TinyPG.CodeGenerators
+{
+    public class BaseGenerator
+    {
+        protected string templateName;
+        private string fileName;
+
+        public BaseGenerator(string templateName)
+        {
+            this.templateName = templateName;
+            FileName = templateName;
+            
+        }
+
+        public virtual string FileName
+        {
+            get { return this.fileName; }
+            set { this.fileName = value; }
+        }
+    }
+}

--- a/TinyPG/CodeGenerators/CSharp/ParseTreeGenerator.cs
+++ b/TinyPG/CodeGenerators/CSharp/ParseTreeGenerator.cs
@@ -1,23 +1,17 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
+﻿using System.Text;
 using System.IO;
-using TinyPG;
 using TinyPG.Compiler;
 using System.Text.RegularExpressions;
 
 namespace TinyPG.CodeGenerators.CSharp
 {
-    public class ParseTreeGenerator : ICodeGenerator
+    public class ParseTreeGenerator : BaseGenerator, ICodeGenerator
     {
         internal ParseTreeGenerator()
+            : base("ParseTree.cs")
         {
         }
 
-        public string FileName
-        {
-            get { return "ParseTree.cs"; }
-        }
 
         public string Generate(Grammar Grammar, bool Debug)
         {
@@ -25,7 +19,7 @@ namespace TinyPG.CodeGenerators.CSharp
                 return null;
 
             // copy the parse tree file (optionally)
-            string parsetree = File.ReadAllText(Grammar.GetTemplatePath() + FileName);
+            string parsetree = File.ReadAllText(Grammar.GetTemplatePath() + templateName);
 
             StringBuilder evalsymbols = new StringBuilder();
             StringBuilder evalmethods = new StringBuilder();
@@ -50,9 +44,7 @@ namespace TinyPG.CodeGenerators.CSharp
                     if (s.Name == "Start") // return a nice warning message from root object.
                         evalmethods.AppendLine("            return \"Could not interpret input; no semantics implemented.\";");
                     else
-                        evalmethods.AppendLine("            foreach (var node in Nodes)\r\n" +
-                                               "                node.Eval(tree, paramlist);\r\n" +
-                                               "            return null;");
+                        evalmethods.AppendLine("            throw new NotImplementedException();");
 
                     // otherwise simply not implemented!
                 }

--- a/TinyPG/CodeGenerators/CSharp/ParseTreeGenerator.cs
+++ b/TinyPG/CodeGenerators/CSharp/ParseTreeGenerator.cs
@@ -12,7 +12,6 @@ namespace TinyPG.CodeGenerators.CSharp
         {
         }
 
-
         public string Generate(Grammar Grammar, bool Debug)
         {
             if (string.IsNullOrEmpty(Grammar.GetTemplatePath()))
@@ -44,7 +43,9 @@ namespace TinyPG.CodeGenerators.CSharp
                     if (s.Name == "Start") // return a nice warning message from root object.
                         evalmethods.AppendLine("            return \"Could not interpret input; no semantics implemented.\";");
                     else
-                        evalmethods.AppendLine("            throw new NotImplementedException();");
+                        evalmethods.AppendLine("            foreach (var node in Nodes)\r\n" +
+                                               "                node.Eval(tree, paramlist);\r\n" +
+                                               "            return null;");
 
                     // otherwise simply not implemented!
                 }

--- a/TinyPG/CodeGenerators/CSharp/ParserGenerator.cs
+++ b/TinyPG/CodeGenerators/CSharp/ParserGenerator.cs
@@ -87,7 +87,7 @@ namespace TinyPG.CodeGenerators.CSharp
                     sb.AppendLine(Indent + "node.Token.UpdateRange(tok);");
                     sb.AppendLine(Indent + "node.Nodes.Add(n);");
                     sb.AppendLine(Indent + "if (tok.Type != TokenType." + r.Symbol.Name + ") {");
-                    sb.AppendLine(Indent + "    tree.Errors.Add(new ParseError(\"Unexpected token '\" + tok.Text.Replace(\"\\n\", \"\") + \"' found. Expected \" + TokenType." + r.Symbol.Name + ".ToString(), 0x1001, 0, tok.StartPos, tok.StartPos, tok.Length));");
+                    sb.AppendLine(Indent + "    tree.Errors.Add(new ParseError(\"Unexpected token '\" + tok.Text.Replace(\"\\n\", \"\") + \"' found. Expected \" + TokenType." + r.Symbol.Name + ".ToString(), 0x1001, tok));");
                     sb.AppendLine(Indent + "    return;");
                     sb.AppendLine(Indent + "}");
                     break;
@@ -236,7 +236,7 @@ namespace TinyPG.CodeGenerators.CSharp
                         sb.AppendLine(Indent + "        break;");
                     }
                     sb.AppendLine(Indent + "    default:");
-                    sb.AppendLine(Indent + "        tree.Errors.Add(new ParseError(\"Unexpected token '\" + tok.Text.Replace(\"\\n\", \"\") + \"' found.\", 0x0002, 0, tok.StartPos, tok.StartPos, tok.Length));");
+                    sb.AppendLine(Indent + "        tree.Errors.Add(new ParseError(\"Unexpected token '\" + tok.Text.Replace(\"\\n\", \"\") + \"' found.\", 0x0002, tok));");
                     sb.AppendLine(Indent + "        break;");
                     sb.AppendLine(Indent + "}" + Helper.AddComment("Choice Rule"));
                     break;

--- a/TinyPG/CodeGenerators/CSharp/ParserGenerator.cs
+++ b/TinyPG/CodeGenerators/CSharp/ParserGenerator.cs
@@ -1,21 +1,14 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
+﻿using System.Text;
 using System.IO;
-using TinyPG;
 using TinyPG.Compiler;
 
 namespace TinyPG.CodeGenerators.CSharp
 {
-    public class ParserGenerator : ICodeGenerator
+    public class ParserGenerator : BaseGenerator, ICodeGenerator
     {
         internal ParserGenerator()
+            : base("Parser.cs")
         {
-        }
-
-        public string FileName
-        {
-            get { return "Parser.cs"; }
         }
 
         public string Generate(Grammar Grammar, bool Debug)
@@ -25,7 +18,7 @@ namespace TinyPG.CodeGenerators.CSharp
 
             // generate the parser file
             StringBuilder parsers = new StringBuilder();
-            string parser = File.ReadAllText(Grammar.GetTemplatePath() + FileName);
+            string parser = File.ReadAllText(Grammar.GetTemplatePath() + templateName);
 
             // build non terminal tokens
             foreach (NonTerminalSymbol s in Grammar.GetNonTerminals())
@@ -94,7 +87,7 @@ namespace TinyPG.CodeGenerators.CSharp
                     sb.AppendLine(Indent + "node.Token.UpdateRange(tok);");
                     sb.AppendLine(Indent + "node.Nodes.Add(n);");
                     sb.AppendLine(Indent + "if (tok.Type != TokenType." + r.Symbol.Name + ") {");
-                    sb.AppendLine(Indent + "    tree.Errors.Add(new ParseError(\"Unexpected token '\" + tok.Text.Replace(\"\\n\", \"\") + \"' found. Expected \" + TokenType." + r.Symbol.Name + ".ToString(), 0x1001, tok));");
+                    sb.AppendLine(Indent + "    tree.Errors.Add(new ParseError(\"Unexpected token '\" + tok.Text.Replace(\"\\n\", \"\") + \"' found. Expected \" + TokenType." + r.Symbol.Name + ".ToString(), 0x1001, 0, tok.StartPos, tok.StartPos, tok.Length));");
                     sb.AppendLine(Indent + "    return;");
                     sb.AppendLine(Indent + "}");
                     break;
@@ -243,7 +236,7 @@ namespace TinyPG.CodeGenerators.CSharp
                         sb.AppendLine(Indent + "        break;");
                     }
                     sb.AppendLine(Indent + "    default:");
-                    sb.AppendLine(Indent + "        tree.Errors.Add(new ParseError(\"Unexpected token '\" + tok.Text.Replace(\"\\n\", \"\") + \"' found.\", 0x0002, tok));");
+                    sb.AppendLine(Indent + "        tree.Errors.Add(new ParseError(\"Unexpected token '\" + tok.Text.Replace(\"\\n\", \"\") + \"' found.\", 0x0002, 0, tok.StartPos, tok.StartPos, tok.Length));");
                     sb.AppendLine(Indent + "        break;");
                     sb.AppendLine(Indent + "}" + Helper.AddComment("Choice Rule"));
                     break;

--- a/TinyPG/CodeGenerators/CSharp/ScannerGenerator.cs
+++ b/TinyPG/CodeGenerators/CSharp/ScannerGenerator.cs
@@ -8,7 +8,7 @@ namespace TinyPG.CodeGenerators.CSharp
     public class ScannerGenerator : BaseGenerator, ICodeGenerator
     {
         internal ScannerGenerator()
-             : base("Scanner.cs")
+            : base("Scanner.cs")
         {
         }
 
@@ -29,6 +29,9 @@ namespace TinyPG.CodeGenerators.CSharp
                 skiplist.AppendLine("            SkipList.Add(TokenType." + s.Name + ");");
             }
 
+            if (Grammar.FileAndLine != null)
+                skiplist.AppendLine("            FileAndLine = TokenType." + Grammar.FileAndLine.Name + ";");
+
             // build system tokens
             tokentype.AppendLine("\r\n            //Non terminal tokens:");
             tokentype.AppendLine(Helper.Outline("_NONE_", 3, "= 0,", 5));
@@ -47,7 +50,13 @@ namespace TinyPG.CodeGenerators.CSharp
             bool first = true;
             foreach (TerminalSymbol s in Grammar.GetTerminals())
             {
-                regexps.Append("            regex = new Regex(" + s.Expression.ToString() + ", RegexOptions.Compiled);\r\n");
+                regexps.Append("            regex = new Regex(" + s.Expression.ToString() + ", RegexOptions.Compiled");
+
+                if (s.Attributes.ContainsKey("IgnoreCase"))
+                    regexps.Append(" | RegexOptions.IgnoreCase");
+
+                regexps.Append(");\r\n");
+
                 regexps.Append("            Patterns.Add(TokenType." + s.Name + ", regex);\r\n");
                 regexps.Append("            Tokens.Add(TokenType." + s.Name + ");\r\n\r\n");
 

--- a/TinyPG/CodeGenerators/CSharp/ScannerGenerator.cs
+++ b/TinyPG/CodeGenerators/CSharp/ScannerGenerator.cs
@@ -1,21 +1,15 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Text;
 using System.IO;
-using TinyPG;
 using TinyPG.Compiler;
 
 namespace TinyPG.CodeGenerators.CSharp
 {
-    public class ScannerGenerator : ICodeGenerator
+    public class ScannerGenerator : BaseGenerator, ICodeGenerator
     {
         internal ScannerGenerator()
+             : base("Scanner.cs")
         {
-        }
-
-        public string FileName
-        {
-            get { return "Scanner.cs"; }
         }
 
         public string Generate(Grammar Grammar, bool Debug)
@@ -23,7 +17,7 @@ namespace TinyPG.CodeGenerators.CSharp
             if (string.IsNullOrEmpty(Grammar.GetTemplatePath()))
                 return null;
 
-            string scanner = File.ReadAllText(Grammar.GetTemplatePath() + FileName);
+            string scanner = File.ReadAllText(Grammar.GetTemplatePath() + templateName);
 
             int counter = 2;
             StringBuilder tokentype = new StringBuilder();
@@ -34,9 +28,6 @@ namespace TinyPG.CodeGenerators.CSharp
             {
                 skiplist.AppendLine("            SkipList.Add(TokenType." + s.Name + ");");
             }
-
-            if (Grammar.FileAndLine != null)
-                skiplist.AppendLine("            FileAndLine = TokenType." + Grammar.FileAndLine.Name + ";");
 
             // build system tokens
             tokentype.AppendLine("\r\n            //Non terminal tokens:");
@@ -56,13 +47,7 @@ namespace TinyPG.CodeGenerators.CSharp
             bool first = true;
             foreach (TerminalSymbol s in Grammar.GetTerminals())
             {
-                regexps.Append("            regex = new Regex(" + s.Expression.ToString() + ", RegexOptions.Compiled");
-
-                if (s.Attributes.ContainsKey("IgnoreCase"))
-                    regexps.Append(" | RegexOptions.IgnoreCase");
-                
-                regexps.Append(");\r\n");                    
-
+                regexps.Append("            regex = new Regex(" + s.Expression.ToString() + ", RegexOptions.Compiled);\r\n");
                 regexps.Append("            Patterns.Add(TokenType." + s.Name + ", regex);\r\n");
                 regexps.Append("            Tokens.Add(TokenType." + s.Name + ");\r\n\r\n");
 

--- a/TinyPG/CodeGenerators/CSharp/TextHighlighterGenerator.cs
+++ b/TinyPG/CodeGenerators/CSharp/TextHighlighterGenerator.cs
@@ -1,21 +1,15 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Text;
 using System.IO;
-using TinyPG;
 using TinyPG.Compiler;
 
 namespace TinyPG.CodeGenerators.CSharp
 {
-    public class TextHighlighterGenerator : ICodeGenerator
+    public class TextHighlighterGenerator : BaseGenerator, ICodeGenerator
     {
         internal TextHighlighterGenerator()
+            : base("TextHighlighter.cs")
         {
-        }
-
-        public string FileName
-        {
-            get { return "TextHighlighter.cs"; }
         }
 
         public string Generate(Grammar Grammar, bool Debug)
@@ -23,7 +17,7 @@ namespace TinyPG.CodeGenerators.CSharp
             if (string.IsNullOrEmpty(Grammar.GetTemplatePath()))
                 return null;
 
-            string generatedtext = File.ReadAllText(Grammar.GetTemplatePath() + FileName);
+            string generatedtext = File.ReadAllText(Grammar.GetTemplatePath() + templateName);
             StringBuilder tokens = new StringBuilder();
             StringBuilder colors = new StringBuilder();
 

--- a/TinyPG/CodeGenerators/CodeGeneratorFactory.cs
+++ b/TinyPG/CodeGenerators/CodeGeneratorFactory.cs
@@ -75,7 +75,7 @@ namespace TinyPG.CodeGenerators
                 case "vb":
                     return new Microsoft.VisualBasic.VBCodeProvider();
                 default:
-                    return new Microsoft.CSharp.CSharpCodeProvider();
+                    return new Microsoft.CSharp.CSharpCodeProvider(new Dictionary<string, string> { { "CompilerVersion", "v3.5" } });
             }
         }
     }

--- a/TinyPG/CodeGenerators/CodeGeneratorFactory.cs
+++ b/TinyPG/CodeGenerators/CodeGeneratorFactory.cs
@@ -75,7 +75,7 @@ namespace TinyPG.CodeGenerators
                 case "vb":
                     return new Microsoft.VisualBasic.VBCodeProvider();
                 default:
-                    return new Microsoft.CSharp.CSharpCodeProvider(new Dictionary<string, string> { { "CompilerVersion", "v3.5" } });
+                    return new Microsoft.CSharp.CSharpCodeProvider();
             }
         }
     }

--- a/TinyPG/CodeGenerators/ICodeGenerator.cs
+++ b/TinyPG/CodeGenerators/ICodeGenerator.cs
@@ -13,7 +13,7 @@ namespace TinyPG.CodeGenerators
         /// the target filename where the output of Generate should be stored. This value
         /// must be implemented by the implementing class
         /// </summary>
-        string FileName { get; }
+        string FileName { get; set; }
 
         /// <summary>
         /// Generates an output file based on the grammar

--- a/TinyPG/CodeGenerators/VBNet/ParseTreeGenerator.cs
+++ b/TinyPG/CodeGenerators/VBNet/ParseTreeGenerator.cs
@@ -7,7 +7,8 @@ namespace TinyPG.CodeGenerators.VBNet
 {
     public class ParseTreeGenerator : BaseGenerator, ICodeGenerator
     {
-        internal ParseTreeGenerator(): base( "ParseTree.vb")
+        internal ParseTreeGenerator()
+            : base("ParseTree.vb")
         {
         }
 
@@ -17,7 +18,7 @@ namespace TinyPG.CodeGenerators.VBNet
                 return null;
 
             // copy the parse tree file (optionally)
-            string parsetree = File.ReadAllText(Grammar.GetTemplatePath() + FileName);
+            string parsetree = File.ReadAllText(Grammar.GetTemplatePath() + templateName);
 
             StringBuilder evalsymbols = new StringBuilder();
             StringBuilder evalmethods = new StringBuilder();

--- a/TinyPG/CodeGenerators/VBNet/ParseTreeGenerator.cs
+++ b/TinyPG/CodeGenerators/VBNet/ParseTreeGenerator.cs
@@ -1,22 +1,14 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
+﻿using System.Text;
 using System.IO;
-using TinyPG;
 using TinyPG.Compiler;
 using System.Text.RegularExpressions;
 
 namespace TinyPG.CodeGenerators.VBNet
 {
-    public class ParseTreeGenerator : ICodeGenerator
+    public class ParseTreeGenerator : BaseGenerator, ICodeGenerator
     {
-        internal ParseTreeGenerator()
+        internal ParseTreeGenerator(): base( "ParseTree.vb")
         {
-        }
-
-        public string FileName
-        {
-            get { return "ParseTree.vb"; }
         }
 
         public string Generate(Grammar Grammar, bool Debug)
@@ -82,14 +74,14 @@ namespace TinyPG.CodeGenerators.VBNet
                 parsetree = parsetree.Replace(@"<%ImplementsIParseErrorLength%>", " Implements IParseError.Length");
                 parsetree = parsetree.Replace(@"<%ImplementsIParseErrorMessage%>", " Implements IParseError.Message");
 
-                string inodes =       "        Public Shared Function Node2INode(ByVal node As ParseNode) As IParseNode\r\n"
+                string inodes = "        Public Shared Function Node2INode(ByVal node As ParseNode) As IParseNode\r\n"
                                     + "            Return DirectCast(node, IParseNode)\r\n"
                                     + "        End Function\r\n\r\n"
                                     + "        Public ReadOnly Property INodes() As List(Of IParseNode) Implements IParseNode.INodes\r\n"
                                     + "            Get\r\n"
                                     + "                Return Nodes.ConvertAll(Of IParseNode)(New Converter(Of ParseNode, IParseNode)(AddressOf Node2INode))\r\n"
                                     + "            End Get\r\n"
-                                    + "        End Property\r\n"; 
+                                    + "        End Property\r\n";
                 parsetree = parsetree.Replace(@"<%INodesGet%>", inodes);
                 parsetree = parsetree.Replace(@"<%ImplementsIParseNodeText%>", " Implements IParseNode.Text");
 

--- a/TinyPG/CodeGenerators/VBNet/ParserGenerator.cs
+++ b/TinyPG/CodeGenerators/VBNet/ParserGenerator.cs
@@ -1,21 +1,14 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
+﻿using System.Text;
 using System.IO;
-using TinyPG;
 using TinyPG.Compiler;
+
 
 namespace TinyPG.CodeGenerators.VBNet
 {
-    public class ParserGenerator : ICodeGenerator
+    public class ParserGenerator : BaseGenerator, ICodeGenerator
     {
-        internal ParserGenerator()
+        internal ParserGenerator() : base( "Parser.vb")
         {
-        }
-
-        public string FileName
-        {
-            get { return "Parser.vb"; }
         }
 
         public string Generate(Grammar Grammar, bool Debug)
@@ -93,7 +86,7 @@ namespace TinyPG.CodeGenerators.VBNet
                     sb.AppendLine(Indent + "node.Token.UpdateRange(tok)");
                     sb.AppendLine(Indent + "node.Nodes.Add(n)");
                     sb.AppendLine(Indent + "If tok.Type <> TokenType." + r.Symbol.Name + " Then");
-                    sb.AppendLine(Indent + "    m_tree.Errors.Add(New ParseError(\"Unexpected token '\" + tok.Text.Replace(\"\\n\", \"\") + \"' found. Expected \" + TokenType." + r.Symbol.Name + ".ToString(), &H1001, tok))");
+                    sb.AppendLine(Indent + "    m_tree.Errors.Add(New ParseError(\"Unexpected token '\" + tok.Text.Replace(\"\\n\", \"\") + \"' found. Expected \" + TokenType." + r.Symbol.Name + ".ToString(), &H1001, 0, tok.StartPos, tok.StartPos, tok.EndPos - tok.StartPos))");
                     sb.AppendLine(Indent + "    Return\r\n");
                     sb.AppendLine(Indent + "End If\r\n");
                     break;
@@ -240,7 +233,7 @@ namespace TinyPG.CodeGenerators.VBNet
                         }
                     }
                     sb.AppendLine(Indent + "    Case Else");
-                    sb.AppendLine(Indent + "        m_tree.Errors.Add(new ParseError(\"Unexpected token '\" + tok.Text.Replace(\"\\n\", \"\") + \"' found.\", &H0002, tok))");
+                    sb.AppendLine(Indent + "        m_tree.Errors.Add(new ParseError(\"Unexpected token '\" + tok.Text.Replace(\"\\n\", \"\") + \"' found.\", &H0002, 0, tok.StartPos, tok.StartPos, tok.EndPos - tok.StartPos))");
                     sb.AppendLine(Indent + "        Exit Select");
                     sb.AppendLine(Indent + "End Select" + Helper.AddComment("'", "Choice Rule"));
                     break;

--- a/TinyPG/CodeGenerators/VBNet/ParserGenerator.cs
+++ b/TinyPG/CodeGenerators/VBNet/ParserGenerator.cs
@@ -2,12 +2,12 @@
 using System.IO;
 using TinyPG.Compiler;
 
-
 namespace TinyPG.CodeGenerators.VBNet
 {
     public class ParserGenerator : BaseGenerator, ICodeGenerator
     {
-        internal ParserGenerator() : base( "Parser.vb")
+        internal ParserGenerator()
+            : base("Parser.vb")
         {
         }
 
@@ -18,7 +18,7 @@ namespace TinyPG.CodeGenerators.VBNet
 
             // generate the parser file
             StringBuilder parsers = new StringBuilder();
-            string parser = File.ReadAllText(Grammar.GetTemplatePath() + FileName);
+            string parser = File.ReadAllText(Grammar.GetTemplatePath() + templateName);
 
             // build non terminal tokens
             foreach (NonTerminalSymbol s in Grammar.GetNonTerminals())
@@ -86,7 +86,7 @@ namespace TinyPG.CodeGenerators.VBNet
                     sb.AppendLine(Indent + "node.Token.UpdateRange(tok)");
                     sb.AppendLine(Indent + "node.Nodes.Add(n)");
                     sb.AppendLine(Indent + "If tok.Type <> TokenType." + r.Symbol.Name + " Then");
-                    sb.AppendLine(Indent + "    m_tree.Errors.Add(New ParseError(\"Unexpected token '\" + tok.Text.Replace(\"\\n\", \"\") + \"' found. Expected \" + TokenType." + r.Symbol.Name + ".ToString(), &H1001, 0, tok.StartPos, tok.StartPos, tok.EndPos - tok.StartPos))");
+                    sb.AppendLine(Indent + "    m_tree.Errors.Add(New ParseError(\"Unexpected token '\" + tok.Text.Replace(\"\\n\", \"\") + \"' found. Expected \" + TokenType." + r.Symbol.Name + ".ToString(), &H1001, tok))");
                     sb.AppendLine(Indent + "    Return\r\n");
                     sb.AppendLine(Indent + "End If\r\n");
                     break;
@@ -233,7 +233,7 @@ namespace TinyPG.CodeGenerators.VBNet
                         }
                     }
                     sb.AppendLine(Indent + "    Case Else");
-                    sb.AppendLine(Indent + "        m_tree.Errors.Add(new ParseError(\"Unexpected token '\" + tok.Text.Replace(\"\\n\", \"\") + \"' found.\", &H0002, 0, tok.StartPos, tok.StartPos, tok.EndPos - tok.StartPos))");
+                    sb.AppendLine(Indent + "        m_tree.Errors.Add(new ParseError(\"Unexpected token '\" + tok.Text.Replace(\"\\n\", \"\") + \"' found.\", &H0002, tok))");
                     sb.AppendLine(Indent + "        Exit Select");
                     sb.AppendLine(Indent + "End Select" + Helper.AddComment("'", "Choice Rule"));
                     break;

--- a/TinyPG/CodeGenerators/VBNet/ScannerGenerator.cs
+++ b/TinyPG/CodeGenerators/VBNet/ScannerGenerator.cs
@@ -7,7 +7,8 @@ namespace TinyPG.CodeGenerators.VBNet
 {
     public class ScannerGenerator : BaseGenerator, ICodeGenerator
     {
-        internal ScannerGenerator() : base("Scanner.vb")
+        internal ScannerGenerator()
+            : base("Scanner.vb")
         {
         }
 
@@ -16,7 +17,7 @@ namespace TinyPG.CodeGenerators.VBNet
             if (string.IsNullOrEmpty(Grammar.GetTemplatePath()))
                 return null;
 
-            string scanner = File.ReadAllText(Grammar.GetTemplatePath() + FileName);
+            string scanner = File.ReadAllText(Grammar.GetTemplatePath() + templateName);
 
             int counter = 2;
             StringBuilder tokentype = new StringBuilder();
@@ -74,7 +75,7 @@ namespace TinyPG.CodeGenerators.VBNet
                 scanner = scanner.Replace(@"<%ImplementsITokenLength%>", " Implements IToken.Length");
                 scanner = scanner.Replace(@"<%ImplementsITokenText%>", " Implements IToken.Text");
                 scanner = scanner.Replace(@"<%ImplementsITokenToString%>", " Implements IToken.ToString");
-                
+
             }
             else
             {

--- a/TinyPG/CodeGenerators/VBNet/ScannerGenerator.cs
+++ b/TinyPG/CodeGenerators/VBNet/ScannerGenerator.cs
@@ -1,21 +1,14 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Text;
 using System.IO;
-using TinyPG;
 using TinyPG.Compiler;
 
 namespace TinyPG.CodeGenerators.VBNet
 {
-    public class ScannerGenerator : ICodeGenerator
+    public class ScannerGenerator : BaseGenerator, ICodeGenerator
     {
-        internal ScannerGenerator()
+        internal ScannerGenerator() : base("Scanner.vb")
         {
-        }
-
-        public string FileName
-        {
-            get { return "Scanner.vb"; }
         }
 
         public string Generate(Grammar Grammar, bool Debug)

--- a/TinyPG/CodeGenerators/VBNet/TextHighlighterGenerator.cs
+++ b/TinyPG/CodeGenerators/VBNet/TextHighlighterGenerator.cs
@@ -1,21 +1,14 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Text;
 using System.IO;
-using TinyPG;
 using TinyPG.Compiler;
 
 namespace TinyPG.CodeGenerators.VBNet
 {
-    public class TextHighlighterGenerator : ICodeGenerator
+    public class TextHighlighterGenerator : BaseGenerator,ICodeGenerator
     {
-        internal TextHighlighterGenerator()
+        internal TextHighlighterGenerator() : base("TextHighlighter.vb")
         {
-        }
-
-        public string FileName
-        {
-            get { return "TextHighlighter.vb"; }
         }
 
         public string Generate(Grammar Grammar, bool Debug)

--- a/TinyPG/CodeGenerators/VBNet/TextHighlighterGenerator.cs
+++ b/TinyPG/CodeGenerators/VBNet/TextHighlighterGenerator.cs
@@ -5,9 +5,10 @@ using TinyPG.Compiler;
 
 namespace TinyPG.CodeGenerators.VBNet
 {
-    public class TextHighlighterGenerator : BaseGenerator,ICodeGenerator
+    public class TextHighlighterGenerator : BaseGenerator, ICodeGenerator
     {
-        internal TextHighlighterGenerator() : base("TextHighlighter.vb")
+        internal TextHighlighterGenerator()
+            : base("TextHighlighter.vb")
         {
         }
 
@@ -16,7 +17,7 @@ namespace TinyPG.CodeGenerators.VBNet
             if (string.IsNullOrEmpty(Grammar.GetTemplatePath()))
                 return null;
 
-            string generatedtext = File.ReadAllText(Grammar.GetTemplatePath() + FileName);
+            string generatedtext = File.ReadAllText(Grammar.GetTemplatePath() + templateName);
             StringBuilder tokens = new StringBuilder();
             StringBuilder colors = new StringBuilder();
 

--- a/TinyPG/Compiler/Compiler.cs
+++ b/TinyPG/Compiler/Compiler.cs
@@ -9,11 +9,8 @@
 //-----------------------------------------------------------------------
 using System;
 using System.Collections.Generic;
-using System.Text;
-using System.IO;
 using CodeDom = System.CodeDom.Compiler;
 using System.Reflection;
-using System.Text.RegularExpressions;
 
 using TinyPG.CodeGenerators;
 using TinyPG.Debug;
@@ -102,7 +99,7 @@ namespace TinyPG.Compiler
             // reference this assembly to share interfaces (for debugging only)
 
             string tinypgfile = Assembly.GetExecutingAssembly().Location;
-            compilerparams.ReferencedAssemblies.Add(tinypgfile); 
+            compilerparams.ReferencedAssemblies.Add(tinypgfile);
 
             // generate the code with debug interface enabled
             List<string> sources = new List<string>();
@@ -155,7 +152,7 @@ namespace TinyPG.Compiler
 
             object treeinstance = parsertype.InvokeMember("Parse", BindingFlags.InvokeMethod, null, parserinstance, new object[] { input, string.Empty });
             IParseTree itree = treeinstance as IParseTree;
-            
+
             compilerresult.ParseTree = itree;
             Type treetype = treeinstance.GetType();
 

--- a/TinyPG/Compiler/Compiler.cs
+++ b/TinyPG/Compiler/Compiler.cs
@@ -110,6 +110,9 @@ namespace TinyPG.Compiler
             foreach (Directive d in Grammar.Directives)
             {
                 generator = CodeGeneratorFactory.CreateGenerator(d.Name, language);
+                if (generator != null && d.ContainsKey("FileName"))
+                    generator.FileName = d["FileName"];
+
                 if (generator != null && d["Generate"].ToLower() == "true")
                     sources.Add(generator.Generate(Grammar, true));
             }

--- a/TinyPG/Compiler/GrammarTree.cs
+++ b/TinyPG/Compiler/GrammarTree.cs
@@ -212,6 +212,7 @@ namespace TinyPG.Compiler
                 case "ParseTree":
                 case "TextHighlighter":
                     names.Add("Generate");
+                    names.Add("FileName");
                     break;
                 default:
                     return null;

--- a/TinyPG/MainForm.cs
+++ b/TinyPG/MainForm.cs
@@ -660,6 +660,9 @@ namespace TinyPG
                 foreach (Directive d in grammar.Directives)
                 {
                     generator = CodeGeneratorFactory.CreateGenerator(d.Name, language);
+                    if (generator != null && d.ContainsKey("FileName"))
+                        generator.FileName = d["FileName"];
+
                     if (generator != null && d["Generate"].ToLower() == "true")
                         File.WriteAllText(grammar.GetOutputPath() + generator.FileName, generator.Generate(grammar, false));
                 }

--- a/TinyPG/Templates/C#/Parser.cs
+++ b/TinyPG/Templates/C#/Parser.cs
@@ -17,13 +17,17 @@ namespace <%Namespace%>
             this.scanner = scanner;
         }
 
-        public <%IParseTree%> Parse(string input, string fileName)
+         public <%IParseTree%> Parse(string input)
         {
-            tree = new ParseTree();
-            return Parse(input, fileName, tree);
+            return Parse(input, "", new ParseTree());
         }
 
-        public ParseTree Parse(string input, string fileName, ParseTree tree)
+        public <%IParseTree%> Parse(string input, string fileName)
+        {
+            return Parse(input, fileName, new ParseTree());
+        }
+
+        public <%IParseTree%> Parse(string input, string fileName, ParseTree tree)
         {
             scanner.Init(input, fileName);
 

--- a/TinyPG/Templates/C#/Scanner.cs
+++ b/TinyPG/Templates/C#/Scanner.cs
@@ -39,6 +39,11 @@ namespace <%Namespace%>
 <%RegExps%>
         }
 
+        public void Init(string input)
+        {
+            Init(input, "");
+        }
+
         public void Init(string input, string fileName)
         {
             this.Input = input;

--- a/TinyPG/TinyPG.csproj
+++ b/TinyPG/TinyPG.csproj
@@ -43,6 +43,7 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="CodeGenerators\BaseGenerator.cs" />
     <Compile Include="CodeGenerators\CodeGeneratorFactory.cs" />
     <Compile Include="CodeGenerators\ICodeGenerator.cs" />
     <Compile Include="CodeGenerators\CSharp\ParserGenerator.cs" />


### PR DESCRIPTION
Directives @Scanner, @Parser, @ParserTree, @TextHighlighter now accept the option 
FileName="file_name" 
- file_name is the actual name of the generated  file, instead of Scanner.cs, Parser.cs, ParserTree.cs, TextHighlighter.cs (resp). 
- file_name should contains the extension of the file (.cs / .vb)
