### PR TITLE
Bugfix : default outputpath cause NullpointerException

### DIFF
--- a/TinyPG/Compiler/Grammar.cs
+++ b/TinyPG/Compiler/Grammar.cs
@@ -155,8 +155,6 @@ namespace TinyPG.Compiler
             if (!d.ContainsKey("OutputPath"))
                 d["OutputPath"] = "./"; // write files to current path
             if (!d.ContainsKey("Language"))
-                d["OutputPath"] = "C#"; // write files to current path
-            if (!d.ContainsKey("Language"))
                 d["Language"] = "C#"; // set default language
             if (!d.ContainsKey("TemplatePath"))
             {


### PR DESCRIPTION
- default outputpath was set to C# (langage default)
